### PR TITLE
Get the pip installation work

### DIFF
--- a/pyoculus/__init__.py
+++ b/pyoculus/__init__.py
@@ -1,4 +1,10 @@
-__version__ = '0.1.2'
+try:
+    from importlib import metadata
+except ImportError:
+    # Running on pre-3.8 Python; use importlib-metadata package
+    import importlib_metadata as metadata
+
+__version__ = metadata.version('pyoculus')
 
 from . import problems
 from . import integrators

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,4 @@
+[build-system]
+requires = ["setuptools", "wheel", "numpy"]
+build-backend = "setuptools.build_meta"
+

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,6 @@
 import setuptools
-import numpy.distutils.core
+from numpy.distutils.core import Extension, setup
 from numpy.distutils.fcompiler import get_default_fcompiler
-from pyoculus import __version__
 
 # setup fortran 90 extension
 # ---------------------------------------------------------------------------
@@ -15,7 +14,7 @@ elif compiler == 'intel' or compiler == 'intelem':
     pass
 f90flags.append('-O3')
 
-ext1 = numpy.distutils.core.Extension(
+ext1 = Extension(
     name="pyoculus_spec_fortran_module",
     sources=[
         "pyoculus/problems/SPECfortran/pyvariables.f90",
@@ -27,12 +26,19 @@ ext1 = numpy.distutils.core.Extension(
     extra_f90_compile_args=f90flags
 )
 
+install_requires = [
+    "numpy",
+    "scipy",
+    "importlib-metadata ; python_version<'3.8'"
+]
+    
+
 with open("README.md", "r") as fh:
     long_description = fh.read()
 
-numpy.distutils.core.setup(
+setup(
     name="pyoculus",
-    version=__version__,
+    version='0.1.2',
     description="A Python version of Oculus - The eye into the chaos: a comprehensive magnetic field diagnostic package for non-integrable, toroidal magnetic fields",
     long_description=long_description,
     long_description_content_type="text/markdown",
@@ -48,6 +54,7 @@ numpy.distutils.core.setup(
     packages=setuptools.find_packages(),
     package_data={"": ["pyoculus/problems/SPECfortran/*.f90"]},
     include_package_data=True,
+    install_requires=install_requires,
     ext_modules=[ext1],
     setup_requires=["wheel"],
 )


### PR DESCRIPTION
Hello Zhisong,

We are having trouble getting pyoculus install seamlessly with simsopt, where we specify pyoculus as one of the dependencies.
I made some changes to the installation setup to get pyoculus install with pip framework. 

The changes made are
1. Added a pyproject.toml to install numpy before installing pyoculus. 
2. install_requires keyword added in setup.py. So in a virgin virtual environment, when pyoculus is installed, so is numpy and scipy.
3. Version is specified in setup.py. That version in setup.py is imported into __init__.py. This is opposite to what is being done. Reason for change. Installation via pip fails otherwise.

With all the changes, `pip install .` works without any prior set up by the end user. When the changes are propagated to pypi, one could install it seamlessly in any environment.