### PR TITLE
require numpy<=1.21.5

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 setuptools
 wheel
-numpy
+numpy <= 1.21.5
 scipy
 matplotlib


### PR DESCRIPTION
This forces the use of numpy <=1.21.5, and avoids errors when installing with `pip install `. This however forces the use of python<=3.10.

c.f. #4 