### PR TITLE
update to numpy2.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools", "wheel", "oldest_supported_numpy"]
+requires = ["setuptools", "wheel", "numpy>=2.0"]
 build-backend = "setuptools.build_meta"
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,8 @@
 [build-system]
-requires = ["setuptools", "wheel", "numpy>=2.0"]
+requires = ["setuptools",
+            "wheel", 
+            "numpy>=2.0.0; python_version > '3.8'",
+            "oldest-supported-numpy; python_version <= '3.8'"]
 build-backend = "setuptools.build_meta"
 
 

--- a/setup.py
+++ b/setup.py
@@ -50,7 +50,7 @@ setup(
     package_data={"": ["pyoculus/problems/SPECfortran/*.f90"]},
     include_package_data=True,
     install_requires=[
-    "numpy>1.2.1",
+    "numpy>1.21.1",
     "scipy",
     "importlib-metadata ; python_version<'3.8'",
     "matplotlib",

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ with open("README.md", "r") as fh:
 
 setup(
     name="pyoculus",
-    version='0.3.1',
+    version='0.3.2',
     description="A Python version of Oculus - The eye into the chaos: a comprehensive magnetic field diagnostic package for non-integrable, toroidal magnetic fields",
     long_description=long_description,
     long_description_content_type="text/markdown",
@@ -50,11 +50,11 @@ setup(
     package_data={"": ["pyoculus/problems/SPECfortran/*.f90"]},
     include_package_data=True,
     install_requires=[
-    "numpy",
+    "numpy>=2.0",
     "scipy",
     "importlib-metadata ; python_version<'3.8'",
     "matplotlib",
     ],
     ext_modules=[ext1],
-    setup_requires=["wheel"],
+    setup_requires=["wheel", "numpy>=1.21"],
 )

--- a/setup.py
+++ b/setup.py
@@ -50,11 +50,10 @@ setup(
     package_data={"": ["pyoculus/problems/SPECfortran/*.f90"]},
     include_package_data=True,
     install_requires=[
-    "numpy>=2.0",
+    "numpy>1.2.1",
     "scipy",
     "importlib-metadata ; python_version<'3.8'",
     "matplotlib",
     ],
-    ext_modules=[ext1],
-    setup_requires=["wheel", "numpy>=1.21"],
+    ext_modules=[ext1]
 )


### PR DESCRIPTION
Numpy 2.0 broke the C-API: packages compiled with numpy 1.x cannot run under numpy 2.0.0. 

Since 2.0.0 is default if one `pip install numpy`, a new user will encounter a failure if using a precompiled package. Currently with 'oldest-supported-numpy' as a dependency the users system will downgrade numpy. 

This fix uses numpy2.0 during the build step, and leaves the systems' numpy unchanged. Will also probably fix the issues we had before with numpy versions, as 2.0 compiles the C-API reversel-compatible. 

Tested with numpy 1.25 and 2.0.0. Currently simsopt is waiting for all its API-compiled dependencies to migrate to numpy2.0, so a speedy resolution would be appreciated. 

We should in the future spend time to upgrade the build-system as setup.py is deprecated. 