### PR TITLE
pin setuptools version lt 65

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools",
+requires = ["setuptools<65",
             "wheel", 
             "numpy>=2.0.0; python_version > '3.8'",
             "oldest-supported-numpy; python_version <= '3.8'"]


### PR DESCRIPTION
simsopt CI is failing because setuptools is resolving to a version that has an issue. Pinning it for the build fixes it. Should not cause any harm, setuptools should actually be pinned. 

Working on a meson build, but I don't like the compilation of the fortran shared object step, so implementing this fix now until inspiration strikes on how to do meson right (or meson starts supporting f2py-built extensions). 
