### PR TITLE
Update pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [build-system]
 requires = ["setuptools<65",
             "wheel", 
-            "numpy==2.0.0; python_version > '3.8'",
+            "numpy>=2.0.0; python_version > '3.8'",
             "oldest-supported-numpy; python_version <= '3.8'"]
 build-backend = "setuptools.build_meta"
 


### PR DESCRIPTION
Restricting numpy to 2.0.0 does not work for newer versions of python such 3.13 because the wheels do not exist.